### PR TITLE
style: fix input form fields components to match input-text styles

### DIFF
--- a/.ide/rules/component-styling.mdc
+++ b/.ide/rules/component-styling.mdc
@@ -110,4 +110,4 @@ Size via wrapper in `sizes.ts`; SVG fills wrapper:
 
 **Storybook only:** pass `className="size-full"` on Solar/custom icons used as story props (Button `startIcon`).
 
-For custom icon implementation → `icons.mdc`. For Solar in app UI → peer `@solar-icons/react-perf/Linear`.
+For custom icon implementation → `icons.mdc`. For Solar in app UI → peer `@solar-icons/react-perf` (`/Linear` or `/Bold`).

--- a/.ide/rules/icons.mdc
+++ b/.ide/rules/icons.mdc
@@ -12,10 +12,11 @@ Icons live in `src/components/icons/` — **never** `atoms/`.
 
 | Source                | When                                     | Import                                                  |
 | --------------------- | ---------------------------------------- | ------------------------------------------------------- |
-| Solar Linear          | Default for UI in components and apps    | `@solar-icons/react-perf/Linear`                        |
+| Solar Linear          | Default inside DS components             | `@solar-icons/react-perf/Linear`                        |
+| Solar Bold            | App UI (or DS when Figma specifies Bold) | `@solar-icons/react-perf/Bold`                          |
 | Custom (this package) | Solar can't cover or brand mark required | `icons/custom/`, `icons/sports.tsx`, `icons/logo-flat/` |
 
-Solar is a **peer dependency** — consumers must install `@solar-icons/react-perf`.
+**One peer dependency** — `@solar-icons/react-perf` includes all style subpaths (`Linear`, `Bold`, etc.). Consumers install it once; no separate package per style.
 
 **Add a custom icon only when Solar can't cover it.**
 

--- a/.ide/rules/storybook.mdc
+++ b/.ide/rules/storybook.mdc
@@ -139,7 +139,7 @@ Use design-system spacing in layouts: `gap-12`, `gap-24`.
 
 When adding a custom icon, register it in that file. Group by category in separate story exports (e.g. `Custom`, `Social`, `Sports`, `Logo`).
 
-**Solar icons** are not catalogued here — consumers browse `@solar-icons/react-perf` directly.
+**Solar icons** (Linear, Bold, …) are not catalogued here — consumers browse `@solar-icons/react-perf` directly.
 
 ## New component requirement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ Finalizes v2 API cleanup — standardized size tokens, `destructive` naming, the
 
 ## Breaking changes
 
-| Area                      | Before                       | After                          |
-| ------------------------- | ---------------------------- | ------------------------------ |
-| **LabelChip**             | `size="small"` / `medium` / `large` | `size="s"` / `m` / `l`    |
-| **LabelChip**             | `color="danger"`             | `color="destructive"`          |
-| **ScoreIncreaseDecrease** | `variant` prop for size      | **`size`** prop (`s` / `m` / `l`) |
-| **ScoreIncreaseDecrease** | `danger` prop                | **`destructive`**              |
-| **InfoBox**               | `variant="danger"`           | `variant="destructive"`        |
-| **Text**                  | `color="danger"`             | `color="destructive"` (removed duplicate) |
-| **Toast**                 | `Snackbar` / `useSnackbar` aliases | **Removed** — use `Toast` / `useToast` only |
+| Area                      | Before                                     | After                                                       |
+| ------------------------- | ------------------------------------------ | ----------------------------------------------------------- |
+| **LabelChip**             | `size="small"` / `medium` / `large`        | `size="s"` / `m` / `l`                                      |
+| **LabelChip**             | `color="danger"`                           | `color="destructive"`                                       |
+| **ScoreIncreaseDecrease** | `variant` prop for size                    | **`size`** prop (`s` / `m` / `l`)                           |
+| **ScoreIncreaseDecrease** | `danger` prop                              | **`destructive`**                                           |
+| **InfoBox**               | `variant="danger"`                         | `variant="destructive"`                                     |
+| **Text**                  | `color="danger"`                           | `color="destructive"` (removed duplicate)                   |
+| **Toast**                 | `Snackbar` / `useSnackbar` aliases         | **Removed** — use `Toast` / `useToast` only                 |
 | **Package**               | `@sporteev/sporteev-components/styles.css` | **Removed** — theme-only (`theme.css` + consumer `@source`) |
 
 ---
@@ -74,21 +74,21 @@ Design system 2.0 update — Figma-aligned components, shared sizing/variant pat
 
 ## Breaking changes
 
-| Area          | Before                       | After                                               |
-| ------------- | ---------------------------- | --------------------------------------------------- |
-| **Button**    | `danger` prop / variant      | `color="destructive"`                               |
-| **Button**    | `small` / `medium` / `large` | `s` / `m` / `l` / `xl`                              |
-| **InputText** | `inputSize`                  | `size`                                              |
-| **InputText** | `multiline` prop             | Use **`TextArea`** instead                          |
-| **InputText** | Hover tooltip for helper     | Inline **`helperText`** below field                 |
-| **Toast**     | `danger` variant             | `destructive`                                       |
-| **Toast**     | `Snackbar` / `useSnackbar`   | **`Toast`** / **`useToast`** (aliases removed in 2.2.0) |
-| **Modal**     | `small` / `medium` / `large` | `s` / `m` / `l`                                     |
-| **Modal**     | Custom overlay markup        | Radix Dialog (`@radix-ui/react-dialog`)             |
-| **Text**      | Preset variants (`pageTitle`, `bodySmall`, …) | Typography tokens only: `h1`–`h6`, `body-*`, `caption-*` |
-| **Typography**| Desktop scale at `lg` (1024px) | Desktop scale at **`md` (768px)**                |
-| **Icons**     | `lucide-react`               | Custom icons + `@solar-icons/react-perf` (Linear)   |
-| **Install**   | Solar bundled in library     | **`@solar-icons/react-perf` is a peer dependency** — consumer apps must install it |
+| Area           | Before                                        | After                                                                              |
+| -------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Button**     | `danger` prop / variant                       | `color="destructive"`                                                              |
+| **Button**     | `small` / `medium` / `large`                  | `s` / `m` / `l` / `xl`                                                             |
+| **InputText**  | `inputSize`                                   | `size`                                                                             |
+| **InputText**  | `multiline` prop                              | Use **`TextArea`** instead                                                         |
+| **InputText**  | Hover tooltip for helper                      | Inline **`helperText`** below field                                                |
+| **Toast**      | `danger` variant                              | `destructive`                                                                      |
+| **Toast**      | `Snackbar` / `useSnackbar`                    | **`Toast`** / **`useToast`** (aliases removed in 2.2.0)                            |
+| **Modal**      | `small` / `medium` / `large`                  | `s` / `m` / `l`                                                                    |
+| **Modal**      | Custom overlay markup                         | Radix Dialog (`@radix-ui/react-dialog`)                                            |
+| **Text**       | Preset variants (`pageTitle`, `bodySmall`, …) | Typography tokens only: `h1`–`h6`, `body-*`, `caption-*`                           |
+| **Typography** | Desktop scale at `lg` (1024px)                | Desktop scale at **`md` (768px)**                                                  |
+| **Icons**      | `lucide-react`                                | Custom icons + `@solar-icons/react-perf` (Linear)                                  |
+| **Install**    | Solar bundled in library                      | **`@solar-icons/react-perf` is a peer dependency** — consumer apps must install it |
 
 ---
 
@@ -143,7 +143,7 @@ Design system 2.0 update — Figma-aligned components, shared sizing/variant pat
 
 ### Icons
 
-- Removed `lucide-react`; Solar Linear icons imported per file (`@solar-icons/react-perf/Linear`)
+- Removed `lucide-react`; Solar Linear icons imported per file (`@solar-icons/react-perf/Linear` or `@solar-icons/react-perf/Bold`)
 - **`@solar-icons/react-perf` is a peer dependency** — not bundled in `dist`; consumer apps install and import icons directly for page-level UI
 - Library build externalizes Solar subpaths in Vite (shared copy with the app)
 
@@ -181,7 +181,7 @@ pnpm add @sporteev/sporteev-components @solar-icons/react-perf react react-dom
 <Button variant="primary" color="destructive" size="m">Delete</Button>
 <IconButton variant="outline" color="primary" size="m" aria-label="Search" icon={<SearchIcon />} />
 
-// App-level Solar icons (peer dep — import directly, Linear style)
+// App-level Solar icons (peer dep — import directly, Linear or Bold style)
 import { Settings } from "@solar-icons/react-perf/Linear";
 
 // Fields

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Reusable React components and design tokens for Sporteev apps (and any consumer)
 pnpm add @sporteev/sporteev-components @solar-icons/react-perf
 ```
 
-Peer dependencies: React 18 or 19, `@solar-icons/react-perf` ^2.1.1 (Linear icons used by components and recommended for app UI).
+Peer dependencies: React 18 or 19, `@solar-icons/react-perf` ^2.1.1 — one install covers **Linear** and **Bold** (and other style subpaths). DS components use Linear by default; apps may import either style.
 
 ## Consumer setup (theme-only — recommended)
 
@@ -56,6 +56,7 @@ Import from the **package root only** — no `/atoms` subpaths or deep paths:
 ```tsx
 import { Button, Modal, Text } from "@sporteev/sporteev-components";
 import { Settings } from "@solar-icons/react-perf/Linear";
+import { Star } from "@solar-icons/react-perf/Bold";
 ```
 
 ```tsx

--- a/contributing.md
+++ b/contributing.md
@@ -223,7 +223,9 @@ Full agent rules: [`.ide/rules/radix-primitives.mdc`](./.ide/rules/radix-primiti
 
 ## Icons
 
-- **Default:** Solar Linear — `@solar-icons/react-perf/Linear` (peer dependency; apps must install it)
+- **Solar (peer dep):** install `@solar-icons/react-perf` once — import **Linear** or **Bold** via subpath (`@solar-icons/react-perf/Linear`, `@solar-icons/react-perf/Bold`). No separate package per style.
+- **Default in DS components:** Linear
+- **App UI:** Linear or Bold — match Figma
 - **Custom icons:** only when Solar can't cover the use case — live in `icons/custom/`, use `currentColor`, `PascalCase` + `Icon` suffix
 - **Inside components:** size the icon wrapper in `sizes.ts`, use `[&_svg]:size-full` on the wrapper
 - **Storybook:** one catalog file `icons/icons.stories.tsx` (title `Icons`) — don't add per-icon story files

--- a/src/components/atoms/radio-button/radio-button.stories.tsx
+++ b/src/components/atoms/radio-button/radio-button.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
+import { FIELD_SIZES } from "@/components/molecules/input-text/types";
 import { RadioButton } from "./index";
 
 const meta: Meta<typeof RadioButton> = {
@@ -11,6 +12,11 @@ const meta: Meta<typeof RadioButton> = {
   tags: ["autodocs"],
   argTypes: {
     onChange: { action: "changed" },
+    disabled: { control: "boolean" },
+    size: {
+      control: { type: "select" },
+      options: FIELD_SIZES,
+    },
   },
 };
 
@@ -61,6 +67,24 @@ export const DisabledChecked: Story = {
     checked: true,
     disabled: true,
   },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="space-y-16">
+      {FIELD_SIZES.map((size) => (
+        <RadioButton
+          key={size}
+          label={`${size.toUpperCase()} size`}
+          value={size}
+          checked={size === "m"}
+          size={size}
+          helperText={`Helper text for size ${size}`}
+          onChange={() => {}}
+        />
+      ))}
+    </div>
+  ),
 };
 
 // Radio Group Example

--- a/src/components/atoms/radio-button/radio-button.tsx
+++ b/src/components/atoms/radio-button/radio-button.tsx
@@ -1,15 +1,26 @@
 import React from "react";
 import { cn } from "@/lib/utils";
-import { Text } from "@/components/atoms/text";
 import type { RadioButtonProps } from "./types";
+import {
+  RADIO_CONTROL_SIZE_CLASSES,
+  RADIO_DOT_SIZE_CLASSES,
+  RADIO_HELPER_SIZE_CLASSES,
+  RADIO_LABEL_SIZE_CLASSES,
+  RADIO_OPTION_HELPER_INDENT_CLASSES,
+  RADIO_OPTION_STACK_GAP_CLASSES,
+  RADIO_ROW_GAP_CLASSES,
+} from "./sizes";
 
 export const RadioButton: React.FC<RadioButtonProps> = ({
   label,
   value,
+  name,
   checked = false,
   onChange,
   disabled = false,
+  size = "m",
   helperText,
+  className,
   labelClassName,
   helperTextClassName,
 }) => {
@@ -19,81 +30,73 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
     }
   };
 
-  const baseContainerClasses = "flex flex-col items-start gap-8 mt-4";
-  const baseInputClasses =
-    "transition-colors duration-200 w-16 h-16 m-0 my-auto";
-  const baseHelperTextClasses = "";
-
-  const containerStateClasses = {
-    disabled: "opacity-50 cursor-not-allowed",
-    enabled: "cursor-pointer",
-  };
-
-  const inputStateClasses = {
-    normal: "accent-primary-700",
-  };
-
-  const helperTextStateClasses = {
-    normal: "text-grey-600",
-  };
-
-  const getContainerClasses = () => {
-    return disabled
-      ? containerStateClasses.disabled
-      : containerStateClasses.enabled;
-  };
-
-  const getInputClasses = () => {
-    return inputStateClasses.normal;
-  };
-
-  const getHelperTextClasses = () => {
-    return helperTextStateClasses.normal;
-  };
-
-  const containerClasses = cn(baseContainerClasses, getContainerClasses());
-
-  const inputClasses = cn(baseInputClasses, getInputClasses());
-
-  const labelClasses = cn(
-    "font-medium select-none",
-    {
-      "text-grey-950": !disabled,
-      "text-grey-800": disabled,
-    },
-    labelClassName
-  );
-
-  const helperTextClasses = cn(
-    baseHelperTextClasses,
-    getHelperTextClasses(),
-    helperTextClassName
-  );
-
   return (
-    <div className="flex flex-col justify-center">
-      <label className={containerClasses}>
-        <div className="flex flex-row gap-8">
-          <input
-            type="radio"
-            value={value}
-            checked={checked}
-            onChange={handleChange}
-            disabled={disabled}
-            className={inputClasses}
-          />
-          {label && (
-            <Text variant="body-2" weight="semibold" className={labelClasses}>
-              {label}
-            </Text>
+    <label
+      className={cn(
+        "group flex flex-col",
+        RADIO_OPTION_STACK_GAP_CLASSES[size],
+        disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+        className
+      )}
+    >
+      <div className={cn("flex items-center", RADIO_ROW_GAP_CLASSES[size])}>
+        <span
+          className={cn(
+            "relative flex shrink-0 items-center justify-center rounded-full border bg-white transition-colors duration-200",
+            RADIO_CONTROL_SIZE_CLASSES[size],
+            checked ? "border-primary-600" : "border-grey-400",
+            !disabled &&
+              "group-focus-within:border-primary-600 group-focus-within:shadow-[0_0_0_2px_rgba(0,100,147,0.2)]",
+            disabled && "border-grey-400 bg-grey-300"
           )}
-        </div>
-        {helperText && (
-          <Text variant="body-3" className={helperTextClasses}>
-            {helperText}
-          </Text>
-        )}
-      </label>
-    </div>
+          aria-hidden
+        >
+          <span
+            className={cn(
+              "rounded-full bg-primary-600 transition-transform duration-200",
+              RADIO_DOT_SIZE_CLASSES[size],
+              checked ? "scale-100" : "scale-0",
+              disabled && "bg-grey-600"
+            )}
+          />
+        </span>
+
+        <input
+          type="radio"
+          name={name}
+          value={value}
+          checked={checked}
+          onChange={handleChange}
+          disabled={disabled}
+          className="sr-only"
+        />
+
+        {label ? (
+          <span
+            className={cn(
+              "text-grey-900 select-none",
+              RADIO_LABEL_SIZE_CLASSES[size],
+              disabled && "text-grey-600",
+              labelClassName
+            )}
+          >
+            {label}
+          </span>
+        ) : null}
+      </div>
+
+      {helperText ? (
+        <span
+          className={cn(
+            "text-grey-700",
+            RADIO_HELPER_SIZE_CLASSES[size],
+            RADIO_OPTION_HELPER_INDENT_CLASSES[size],
+            helperTextClassName
+          )}
+        >
+          {helperText}
+        </span>
+      ) : null}
+    </label>
   );
 };

--- a/src/components/atoms/radio-button/sizes.ts
+++ b/src/components/atoms/radio-button/sizes.ts
@@ -1,0 +1,41 @@
+import type { FieldSize } from "@/components/molecules/input-text/types";
+
+export {
+  HELPER_SIZE_CLASSES as RADIO_HELPER_SIZE_CLASSES,
+  LABEL_SIZE_CLASSES as RADIO_LABEL_SIZE_CLASSES,
+} from "@/components/molecules/input-text/sizes";
+
+export const RADIO_CONTROL_SIZE_CLASSES: Record<FieldSize, string> = {
+  s: "size-14",
+  m: "size-16",
+  l: "size-20",
+  xl: "size-24",
+};
+
+export const RADIO_DOT_SIZE_CLASSES: Record<FieldSize, string> = {
+  s: "size-6",
+  m: "size-8",
+  l: "size-10",
+  xl: "size-12",
+};
+
+export const RADIO_ROW_GAP_CLASSES: Record<FieldSize, string> = {
+  s: "gap-6",
+  m: "gap-8",
+  l: "gap-10",
+  xl: "gap-12",
+};
+
+export const RADIO_OPTION_STACK_GAP_CLASSES: Record<FieldSize, string> = {
+  s: "gap-4",
+  m: "gap-6",
+  l: "gap-6",
+  xl: "gap-8",
+};
+
+export const RADIO_OPTION_HELPER_INDENT_CLASSES: Record<FieldSize, string> = {
+  s: "pl-20",
+  m: "pl-24",
+  l: "pl-32",
+  xl: "pl-36",
+};

--- a/src/components/atoms/radio-button/types.ts
+++ b/src/components/atoms/radio-button/types.ts
@@ -1,10 +1,13 @@
+import type { FieldSize } from "@/components/molecules/input-text/types";
+
 export interface RadioButtonProps {
   label?: string;
   value: string;
+  name?: string;
   checked?: boolean;
   onChange?: (value: string) => void;
   disabled?: boolean;
+  size?: FieldSize;
   helperText?: string;
-  labelClassName?: string;
-  helperTextClassName?: string;
+  className?: string;
 }

--- a/src/components/molecules/input-text/field-shell.tsx
+++ b/src/components/molecules/input-text/field-shell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DangerCircle, InfoCircle } from "@solar-icons/react-perf/Linear";
+import { DangerTriangle, InfoCircle } from "@solar-icons/react-perf/Bold";
 import { cn } from "@/lib/utils";
 import {
   FIELD_STACK_GAP,
@@ -50,7 +50,7 @@ export function FieldShell({
       {label ? (
         <label
           className={cn(
-            "flex items-center gap-2 text-grey-900",
+            "text-grey-900 flex items-center gap-2",
             LABEL_SIZE_CLASSES[size],
             labelClassName
           )}
@@ -77,13 +77,16 @@ export function FieldShell({
           role={hasError ? "alert" : undefined}
         >
           {hasError ? (
-            <DangerCircle
+            <DangerTriangle
               className={cn("shrink-0", HELPER_ICON_SIZE_CLASSES[size])}
               aria-hidden
             />
           ) : (
             <InfoCircle
-              className={cn("shrink-0", HELPER_ICON_SIZE_CLASSES[size])}
+              className={cn(
+                "text-primary-600 shrink-0",
+                HELPER_ICON_SIZE_CLASSES[size]
+              )}
               aria-hidden
             />
           )}

--- a/src/components/molecules/input-text/input-text.tsx
+++ b/src/components/molecules/input-text/input-text.tsx
@@ -22,8 +22,8 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
       readOnly = false,
       size = "m",
       type = "text",
-      startAdornment,
-      endAdornment,
+      iconLeft,
+      iconRight,
       containerClassName,
       labelClassName,
       inputClassName,
@@ -48,14 +48,14 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
         helperTextClassName={helperTextClassName}
       >
         <div className="relative flex w-full items-center">
-          {startAdornment ? (
+          {iconLeft ? (
             <div
               className={cn(
-                "pointer-events-none absolute left-8 flex items-center text-grey-500",
+                "text-grey-500 pointer-events-none absolute left-8 flex items-center",
                 adornmentSize
               )}
             >
-              {startAdornment}
+              {iconLeft}
             </div>
           ) : null}
 
@@ -66,8 +66,8 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
               "flex items-center",
               getFieldControlClasses(hasError, disabled, readOnly),
               INPUT_FIELD_SIZE_CLASSES[size],
-              startAdornment && INPUT_ADORNMENT_PADDING[size].start,
-              endAdornment && INPUT_ADORNMENT_PADDING[size].end,
+              iconLeft && INPUT_ADORNMENT_PADDING[size].start,
+              iconRight && INPUT_ADORNMENT_PADDING[size].end,
               inputClassName
             )}
             placeholder={placeholder}
@@ -78,14 +78,14 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
             {...restProps}
           />
 
-          {endAdornment ? (
+          {iconRight ? (
             <div
               className={cn(
-                "pointer-events-none absolute right-8 flex items-center text-grey-500",
+                "pointer-events-none absolute right-8 flex items-center",
                 adornmentSize
               )}
             >
-              {endAdornment}
+              {iconRight}
             </div>
           ) : null}
         </div>

--- a/src/components/molecules/input-text/types.ts
+++ b/src/components/molecules/input-text/types.ts
@@ -14,8 +14,8 @@ export interface BaseFieldProps {
   disabled?: boolean;
   readOnly?: boolean;
   size?: FieldSize;
-  startAdornment?: React.ReactNode;
-  endAdornment?: React.ReactNode;
+  iconLeft?: React.ReactNode;
+  iconRight?: React.ReactNode;
   containerClassName?: string;
   labelClassName?: string;
   inputClassName?: string;

--- a/src/components/molecules/radio-group/radio-group.stories.tsx
+++ b/src/components/molecules/radio-group/radio-group.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { RadioGroup } from "./index";
 import { useState } from "react";
+import { FIELD_SIZES } from "../input-text/types";
 
 const meta: Meta<typeof RadioGroup> = {
   title: "Molecules/RadioGroup",
@@ -10,6 +11,9 @@ const meta: Meta<typeof RadioGroup> = {
   },
   tags: ["autodocs"],
   argTypes: {
+    label: { control: "text" },
+    errorMessage: { control: "text" },
+    helperText: { control: "text" },
     layout: {
       control: { type: "select" },
       options: ["column", "row"],
@@ -17,6 +21,10 @@ const meta: Meta<typeof RadioGroup> = {
     variant: {
       control: { type: "select" },
       options: ["simple", "block"],
+    },
+    size: {
+      control: { type: "select" },
+      options: FIELD_SIZES,
     },
     disabled: {
       control: { type: "boolean" },
@@ -82,6 +90,31 @@ export const WithError: Story = {
     options: sampleOptions,
     errorMessage: "Please select an option",
   },
+};
+
+export const WithGroupHelperText: Story = {
+  args: {
+    label: "Selection with helper text",
+    options: sampleOptions,
+    helperText: "Choose the option that best fits your needs",
+    value: "option1",
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="w-320 space-y-16">
+      {FIELD_SIZES.map((size) => (
+        <RadioGroup
+          key={size}
+          label={`${size.toUpperCase()} size`}
+          options={sampleOptions}
+          value="option1"
+          size={size}
+        />
+      ))}
+    </div>
+  ),
 };
 
 export const Disabled: Story = {

--- a/src/components/molecules/radio-group/radio-group.tsx
+++ b/src/components/molecules/radio-group/radio-group.tsx
@@ -1,8 +1,13 @@
-import React from "react";
+import React, { useId } from "react";
 import { cn } from "@/lib/utils";
 import { RadioButton } from "@/components/atoms/radio-button";
+import { FieldShell } from "@/components/molecules/input-text/field-shell";
 import type { RadioGroupProps } from "./types";
-import { OPTION_WRAPPER_VARIANT_CLASSES } from "./variants";
+import {
+  RADIO_GROUP_COLUMN_GAP_CLASSES,
+  RADIO_GROUP_ROW_GAP_CLASSES,
+} from "./sizes";
+import { getBlockOptionWrapperClasses } from "./variants";
 
 export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
   (
@@ -13,13 +18,19 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
       options,
       required = false,
       errorMessage,
+      helperText,
       disabled = false,
+      size = "m",
+      fullWidth = true,
       layout = "column",
       variant = "simple",
       className,
     },
     ref
   ) => {
+    const groupName = useId();
+    const hasError = Boolean(errorMessage);
+
     const handleOptionChange = (optionValue: string) => {
       if (!disabled && onChange) {
         onChange(optionValue);
@@ -27,51 +38,60 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
     };
 
     return (
-      <div ref={ref} className={cn("flex flex-col gap-12", className)}>
-        {label && (
-          <div className="flex items-center gap-4">
-            <span className="font-medium select-none">{label}</span>
-            {required && <span className="text-red-500">*</span>}
-          </div>
-        )}
-
-        <div
-          className={cn(
-            "flex",
-            layout === "column" ? "flex-col gap-8" : "flex-row flex-wrap",
-            layout === "row" && variant === "simple" ? "gap-16" : "gap-8",
-            disabled && "pointer-events-none opacity-60"
-          )}
+      <div ref={ref} className={cn(fullWidth && "w-full", className)}>
+        <FieldShell
+          size={size}
+          label={label}
+          required={required}
+          helperText={helperText}
+          errorMessage={errorMessage}
+          fullWidth={fullWidth}
         >
-          {options.map((option) => {
-            const isSelected = value === option.value;
-            return (
-              <div
-                key={option.value}
-                className={cn(
-                  OPTION_WRAPPER_VARIANT_CLASSES[variant],
-                  layout === "row" && variant === "block" && "flex-1",
-                  variant === "block" &&
-                    isSelected &&
-                    "border-primary-500 bg-primary-200 shadow-secondary"
-                )}
-              >
-                <RadioButton
-                  label={option.label}
-                  value={option.value}
-                  checked={isSelected}
-                  onChange={handleOptionChange}
-                  disabled={disabled || option.disabled}
-                  helperText={option.helperText}
-                />
-              </div>
-            );
-          })}
-        </div>
+          <div
+            role="radiogroup"
+            aria-required={required || undefined}
+            aria-invalid={hasError || undefined}
+            className={cn(
+              "flex flex-wrap",
+              layout === "column"
+                ? cn("flex-col", RADIO_GROUP_COLUMN_GAP_CLASSES[size])
+                : cn("flex-row", RADIO_GROUP_ROW_GAP_CLASSES[size]),
+              disabled && "pointer-events-none opacity-50"
+            )}
+          >
+            {options.map((option) => {
+              const isSelected = value === option.value;
+              const isOptionDisabled = disabled || option.disabled;
 
-        {errorMessage && (
-          <span className="text-xs text-red-500">{errorMessage}</span>
-        )}
+              return (
+                <div
+                  key={option.value}
+                  className={cn(
+                    variant === "block" &&
+                      getBlockOptionWrapperClasses(
+                        hasError,
+                        Boolean(isOptionDisabled),
+                        size,
+                        isSelected
+                      ),
+                    layout === "row" && variant === "block" && "min-w-0 flex-1"
+                  )}
+                >
+                  <RadioButton
+                    label={option.label}
+                    value={option.value}
+                    name={groupName}
+                    checked={isSelected}
+                    onChange={handleOptionChange}
+                    disabled={isOptionDisabled}
+                    size={size}
+                    helperText={option.helperText}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </FieldShell>
       </div>
     );
   }

--- a/src/components/molecules/radio-group/sizes.ts
+++ b/src/components/molecules/radio-group/sizes.ts
@@ -1,0 +1,22 @@
+import type { FieldSize } from "../input-text/types";
+
+export const RADIO_GROUP_COLUMN_GAP_CLASSES: Record<FieldSize, string> = {
+  s: "gap-6",
+  m: "gap-8",
+  l: "gap-10",
+  xl: "gap-12",
+};
+
+export const RADIO_GROUP_ROW_GAP_CLASSES: Record<FieldSize, string> = {
+  s: "gap-8",
+  m: "gap-12",
+  l: "gap-16",
+  xl: "gap-20",
+};
+
+export const RADIO_BLOCK_OPTION_SIZE_CLASSES: Record<FieldSize, string> = {
+  s: "rounded-8 p-8",
+  m: "rounded-10 p-10",
+  l: "rounded-12 p-12",
+  xl: "rounded-14 p-14",
+};

--- a/src/components/molecules/radio-group/types.ts
+++ b/src/components/molecules/radio-group/types.ts
@@ -1,3 +1,5 @@
+import type { FieldSize } from "../input-text/types";
+
 export type RadioGroupVariant = "simple" | "block";
 
 export const RADIO_GROUP_VARIANTS: RadioGroupVariant[] = ["simple", "block"];
@@ -16,7 +18,10 @@ export interface RadioGroupProps {
   options: RadioOption[];
   required?: boolean;
   errorMessage?: string;
+  helperText?: string;
   disabled?: boolean;
+  size?: FieldSize;
+  fullWidth?: boolean;
   layout?: "column" | "row";
   variant?: RadioGroupVariant;
   className?: string;

--- a/src/components/molecules/radio-group/variants.ts
+++ b/src/components/molecules/radio-group/variants.ts
@@ -1,8 +1,20 @@
-import type { RadioGroupVariant } from "./types";
+import { cn } from "@/lib/utils";
+import { getFieldControlClasses } from "../input-text/field-styles";
+import type { FieldSize } from "../input-text/types";
+import { RADIO_BLOCK_OPTION_SIZE_CLASSES } from "./sizes";
 
-export const OPTION_WRAPPER_VARIANT_CLASSES: Record<RadioGroupVariant, string> =
-  {
-    simple: "",
-    block:
-      "border-2 border-grey-400 rounded-8 p-12 shadow-main transition-all duration-200",
-  };
+export function getBlockOptionWrapperClasses(
+  hasError: boolean,
+  disabled: boolean,
+  size: FieldSize,
+  isSelected: boolean
+): string {
+  return cn(
+    "transition-colors duration-200",
+    getFieldControlClasses(hasError && !isSelected, disabled, false),
+    RADIO_BLOCK_OPTION_SIZE_CLASSES[size],
+    isSelected &&
+      !disabled &&
+      "border-primary-600 bg-primary-200 shadow-[0_0_0_2px_rgba(0,100,147,0.2)]"
+  );
+}

--- a/src/components/molecules/score-increase-decrease/score-increase-decrease.stories.tsx
+++ b/src/components/molecules/score-increase-decrease/score-increase-decrease.stories.tsx
@@ -11,6 +11,9 @@ const meta: Meta<typeof ScoreIncreaseDecrease> = {
   },
   tags: ["autodocs"],
   argTypes: {
+    label: { control: "text" },
+    helperText: { control: "text" },
+    errorMessage: { control: "text" },
     size: {
       control: { type: "select" },
       options: SCORE_INCREASE_DECREASE_SIZES,
@@ -81,12 +84,34 @@ export const Large: Story = {
   },
 };
 
+export const WithLabel: Story = {
+  args: {
+    label: "Team score",
+    helperText: "Adjust the score using the buttons",
+    score: 3,
+    size: "m",
+    onIncrease: () => {},
+    onDecrease: () => {},
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: "Team score",
+    errorMessage: "Score cannot exceed the maximum",
+    score: 10,
+    size: "m",
+    onIncrease: () => {},
+    onDecrease: () => {},
+  },
+};
+
 export const AllSizes: Story = {
   render: () => (
     <div className="flex flex-col items-center gap-32">
       {SCORE_INCREASE_DECREASE_SIZES.map((size) => (
         <div key={size} className="flex flex-col items-center gap-8">
-          <span className="text-sm font-medium text-gray-600">
+          <span className="text-grey-700 text-caption-1 font-medium">
             {size.toUpperCase()}
           </span>
           <ScoreIncreaseDecrease

--- a/src/components/molecules/score-increase-decrease/score-increase-decrease.tsx
+++ b/src/components/molecules/score-increase-decrease/score-increase-decrease.tsx
@@ -1,58 +1,33 @@
 import { useEffect, useState } from "react";
-import { Text } from "@/components/atoms/text";
-import { Button } from "@/components/atoms/button";
+import { IconButton } from "@/components/atoms/button";
+import { FieldShell } from "@/components/molecules/input-text/field-shell";
 import { cn } from "@/lib/utils";
 import { MinusIcon, PlusIcon } from "@/components/icons/custom";
-import type {
-  ScoreIncreaseDecreaseProps,
-  ScoreIncreaseDecreaseSize,
-} from "./types";
-
-const sizeStyles: Record<
-  ScoreIncreaseDecreaseSize,
-  {
-    button: string;
-    score: string;
-    icon: string;
-    text: "body-1" | "body-2" | "body-3";
-  }
-> = {
-  s: {
-    button: "!h-20 !w-20 sm:!h-24 sm:!w-24",
-    score: "h-28 w-32 sm:h-32 sm:w-36",
-    icon: "h-12 w-12 sm:h-16 sm:w-16",
-    text: "body-3",
-  },
-  m: {
-    button: "!h-24 !w-24 sm:!h-32 sm:!w-32",
-    score: "h-36 w-40 sm:h-44 sm:w-48",
-    icon: "h-14 w-14 sm:h-16 sm:w-16",
-    text: "body-2",
-  },
-  l: {
-    button: "!h-32 !w-32 sm:!h-40 sm:!w-40",
-    score: "h-48 w-56 sm:h-56 sm:w-64",
-    icon: "h-16 w-16 sm:h-20 sm:w-20",
-    text: "body-1",
-  },
-};
+import type { ScoreIncreaseDecreaseProps } from "./types";
+import { SCORE_BUTTON_SIZE_MAP, SCORE_ROW_GAP_CLASSES } from "./sizes";
+import { getScoreBoxClasses } from "./variants";
 
 export const ScoreIncreaseDecrease = ({
   score,
   onIncrease,
   onDecrease,
+  onScoreChange,
+  label,
+  required = false,
+  helperText,
+  errorMessage,
   size = "m",
   disabled = false,
   destructive = false,
   inFocus = false,
   editable = true,
   scoreInputEditable = false,
-  onScoreChange,
   min,
   max,
+  className,
 }: ScoreIncreaseDecreaseProps) => {
-  const styles = sizeStyles[size];
   const [inputScore, setInputScore] = useState(score.toString());
+  const hasError = Boolean(errorMessage) || destructive;
 
   const isDecreaseDisabled = disabled || (min !== undefined && score <= min);
   const isIncreaseDisabled = disabled || (max !== undefined && score >= max);
@@ -61,83 +36,84 @@ export const ScoreIncreaseDecrease = ({
     setInputScore(score.toString());
   }, [score]);
 
-  const getScoreBoxClassName = () => {
-    const baseClasses = `flex ${styles.score} items-center justify-center rounded-6 border`;
+  const scoreBoxClassName = getScoreBoxClasses(
+    hasError,
+    disabled,
+    inFocus,
+    size
+  );
 
-    if (disabled) {
-      return `${baseClasses} border-grey-400 bg-grey-300 text-grey-500`;
-    }
-
-    if (inFocus) {
-      return `${baseClasses} border-primary-300 bg-primary-200`;
-    }
-
-    if (destructive) {
-      return `${baseClasses} border-danger-main bg-danger-accent`;
-    }
-
-    return `${baseClasses} border-grey-400`;
-  };
+  const buttonColor = destructive ? "destructive" : "primary";
+  const buttonSize = SCORE_BUTTON_SIZE_MAP[size];
 
   return (
-    <div className="flex w-full items-center justify-center gap-4 sm:gap-8">
-      {editable && (
-        <Button
-          type="button"
-          variant={disabled ? "ghost" : "outline"}
-          size="s"
-          color={destructive ? "destructive" : "primary"}
-          className={cn(
-            `${styles.button} rounded-6 p-0`,
-            disabled ? "bg-grey-300 text-grey-500" : "!border"
-          )}
-          onClick={onDecrease}
-          disabled={isDecreaseDisabled}
-        >
-          <MinusIcon className={styles.icon} />
-        </Button>
-      )}
-      {scoreInputEditable ? (
-        <input
-          type="number"
-          value={inputScore}
-          onChange={(event) => {
-            const nextValue = event.target.value;
-            setInputScore(nextValue);
+    <FieldShell
+      size={size}
+      label={label}
+      required={required}
+      helperText={helperText}
+      errorMessage={errorMessage}
+      fullWidth={false}
+      containerClassName={className}
+    >
+      <div
+        className={cn(
+          "flex items-center justify-center",
+          SCORE_ROW_GAP_CLASSES[size]
+        )}
+      >
+        {editable ? (
+          <IconButton
+            type="button"
+            variant={disabled ? "ghost" : "outline"}
+            color={buttonColor}
+            size={buttonSize}
+            onClick={onDecrease}
+            disabled={isDecreaseDisabled}
+            icon={<MinusIcon className="size-full" />}
+            aria-label="Decrease score"
+          />
+        ) : null}
 
-            const parsedValue = Number(nextValue);
-            if (!Number.isNaN(parsedValue)) {
-              onScoreChange?.(parsedValue);
-            }
-          }}
-          className={cn(
-            getScoreBoxClassName(),
-            "[appearance:textfield] bg-transparent text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-          )}
-          disabled={disabled}
-        />
-      ) : (
-        <Text
-          variant={styles.text}
-          weight="semibold"
-          className={getScoreBoxClassName()}
-        >
-          {score}
-        </Text>
-      )}
-      {editable && (
-        <Button
-          type="button"
-          variant="primary"
-          size="s"
-          color={destructive ? "destructive" : "primary"}
-          className={`${styles.button} rounded-6 p-0`}
-          onClick={onIncrease}
-          disabled={isIncreaseDisabled}
-        >
-          <PlusIcon className={styles.icon} />
-        </Button>
-      )}
-    </div>
+        {scoreInputEditable ? (
+          <input
+            type="number"
+            value={inputScore}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setInputScore(nextValue);
+
+              const parsedValue = Number(nextValue);
+              if (!Number.isNaN(parsedValue)) {
+                onScoreChange?.(parsedValue);
+              }
+            }}
+            className={cn(
+              scoreBoxClassName,
+              "[appearance:textfield] bg-transparent outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            )}
+            disabled={disabled}
+            aria-invalid={hasError || undefined}
+          />
+        ) : (
+          <span className={scoreBoxClassName} aria-live="polite">
+            {score}
+          </span>
+        )}
+
+        {editable ? (
+          <IconButton
+            type="button"
+            variant="primary"
+            color={buttonColor}
+            size={buttonSize}
+            onClick={onIncrease}
+            disabled={isIncreaseDisabled}
+            icon={<PlusIcon className="size-full" />}
+            aria-label="Increase score"
+          />
+        ) : null}
+      </div>
+    </FieldShell>
   );
 };

--- a/src/components/molecules/score-increase-decrease/sizes.ts
+++ b/src/components/molecules/score-increase-decrease/sizes.ts
@@ -1,0 +1,25 @@
+import type { FieldSize } from "../input-text/types";
+
+export { INPUT_FIELD_SIZE_CLASSES as SCORE_BOX_SIZE_CLASSES } from "../input-text/sizes";
+
+export const SCORE_BOX_WIDTH_CLASSES: Record<FieldSize, string> = {
+  s: "w-36",
+  m: "w-48",
+  l: "w-56",
+  xl: "w-72",
+};
+
+/** Field size → icon button size (same for `s`, one step smaller for m/l/xl) */
+export const SCORE_BUTTON_SIZE_MAP: Record<FieldSize, FieldSize> = {
+  s: "s",
+  m: "s",
+  l: "m",
+  xl: "l",
+};
+
+export const SCORE_ROW_GAP_CLASSES: Record<FieldSize, string> = {
+  s: "gap-4",
+  m: "gap-8",
+  l: "gap-10",
+  xl: "gap-12",
+};

--- a/src/components/molecules/score-increase-decrease/types.ts
+++ b/src/components/molecules/score-increase-decrease/types.ts
@@ -1,16 +1,18 @@
-export type ScoreIncreaseDecreaseSize = "s" | "m" | "l";
+import type { FieldSize } from "../input-text/types";
 
-export const SCORE_INCREASE_DECREASE_SIZES: ScoreIncreaseDecreaseSize[] = [
-  "s",
-  "m",
-  "l",
-];
+export type ScoreIncreaseDecreaseSize = FieldSize;
+
+export { FIELD_SIZES as SCORE_INCREASE_DECREASE_SIZES } from "../input-text/types";
 
 export interface ScoreIncreaseDecreaseProps {
   score: number;
   onIncrease: () => void;
   onDecrease: () => void;
   onScoreChange?: (score: number) => void;
+  label?: string;
+  required?: boolean;
+  helperText?: string;
+  errorMessage?: string;
   size?: ScoreIncreaseDecreaseSize;
   disabled?: boolean;
   destructive?: boolean;
@@ -19,4 +21,5 @@ export interface ScoreIncreaseDecreaseProps {
   scoreInputEditable?: boolean;
   min?: number;
   max?: number;
+  className?: string;
 }

--- a/src/components/molecules/score-increase-decrease/variants.ts
+++ b/src/components/molecules/score-increase-decrease/variants.ts
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+import { getFieldControlClasses } from "../input-text/field-styles";
+import type { FieldSize } from "../input-text/types";
+import { SCORE_BOX_SIZE_CLASSES, SCORE_BOX_WIDTH_CLASSES } from "./sizes";
+
+export function getScoreBoxClasses(
+  hasError: boolean,
+  disabled: boolean,
+  inFocus: boolean,
+  size: FieldSize
+): string {
+  return cn(
+    "flex shrink-0 items-center justify-center text-center font-semibold tabular-nums",
+    getFieldControlClasses(hasError, disabled, false),
+    SCORE_BOX_SIZE_CLASSES[size],
+    SCORE_BOX_WIDTH_CLASSES[size],
+    "px-0",
+    hasError && !disabled && "bg-danger-accent",
+    inFocus &&
+      !disabled &&
+      !hasError &&
+      "border-primary-600 shadow-[0_0_0_2px_rgba(0,100,147,0.2)]"
+  );
+}

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -1,2 +1,2 @@
 export { Select, getChipColor } from "./select";
-export type { SelectProps, SelectOption, SelectVariant } from "./types";
+export type { SelectProps, SelectOption } from "./types";

--- a/src/components/molecules/select/select.stories.tsx
+++ b/src/components/molecules/select/select.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Select } from "./index";
+import { FIELD_SIZES } from "../input-text/types";
 import React from "react";
 
 const meta: Meta<typeof Select> = {
@@ -10,15 +11,17 @@ const meta: Meta<typeof Select> = {
   },
   tags: ["autodocs"],
   argTypes: {
-    variant: {
+    label: { control: "text" },
+    placeholder: { control: "text" },
+    errorMessage: { control: "text" },
+    helperText: { control: "text" },
+    required: { control: "boolean" },
+    fullWidth: { control: "boolean" },
+    disabled: { control: "boolean" },
+    searchable: { control: "boolean" },
+    size: {
       control: { type: "select" },
-      options: ["default", "error"],
-    },
-    disabled: {
-      control: { type: "boolean" },
-    },
-    required: {
-      control: { type: "boolean" },
+      options: FIELD_SIZES,
     },
   },
 };
@@ -64,6 +67,30 @@ export const WithError: Story = {
     options: sampleOptions,
     errorMessage: "Please select an option",
   },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    label: "Select with Helper Text",
+    options: sampleOptions,
+    helperText: "Choose the option that best fits your needs",
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="w-320 space-y-16">
+      {FIELD_SIZES.map((size) => (
+        <Select
+          key={size}
+          label={`${size.toUpperCase()} Select`}
+          options={sampleOptions}
+          placeholder={`Size ${size}`}
+          size={size}
+        />
+      ))}
+    </div>
+  ),
 };
 
 export const Disabled: Story = {

--- a/src/components/molecules/select/select.tsx
+++ b/src/components/molecules/select/select.tsx
@@ -7,8 +7,16 @@ import {
   type ChipColor,
   LabelChip,
 } from "@/components/atoms/label-chip";
+import { FieldShell } from "@/components/molecules/input-text/field-shell";
 import { getHashNumber } from "@/lib/utils/hash";
 import type { SelectOption, SelectProps } from "./types";
+import {
+  SELECT_CHECK_ICON_SIZE_CLASSES,
+  SELECT_ICON_SIZE_CLASSES,
+  SELECT_OPTION_PHOTO_SIZE_CLASSES,
+  SELECT_OPTION_SIZE_CLASSES,
+  SELECT_TRIGGER_PHOTO_SIZE_CLASSES,
+} from "./sizes";
 import { getSelectTriggerClasses } from "./variants";
 
 export const getChipColor = (chipText: string): ChipColor => {
@@ -26,8 +34,10 @@ export const Select = React.forwardRef<HTMLDivElement, SelectProps>(
       placeholder = "Select an option",
       required = false,
       errorMessage,
+      helperText,
       disabled = false,
-      variant,
+      size = "m",
+      fullWidth = true,
       className,
       emptyLabel = "No options available",
       searchable = false,
@@ -214,140 +224,158 @@ export const Select = React.forwardRef<HTMLDivElement, SelectProps>(
     };
 
     const displayValue = selectedOption ? selectedOption.label : placeholder;
-
-    const hasError = !!errorMessage;
+    const hasError = Boolean(errorMessage);
     const isDisabled = disabled;
+    const iconSizeClass = SELECT_ICON_SIZE_CLASSES[size];
 
     return (
-      <div ref={ref} className="relative w-full">
-        {label && (
-          <label className="text-grey-950 mb-8 block text-sm font-medium">
-            {label}
-            {required && <span className="ml-4 text-red-500">*</span>}
-          </label>
-        )}
-
-        <div
-          ref={selectRef}
-          className="relative w-full"
-          style={{ zIndex: isOpen ? 9999 : "auto" }}
+      <div ref={ref} className={cn(fullWidth && "w-full")}>
+        <FieldShell
+          size={size}
+          label={label}
+          required={required}
+          helperText={helperText}
+          errorMessage={errorMessage}
+          fullWidth={fullWidth}
         >
           <div
-            ref={selectButtonRef}
-            className={cn(
-              getSelectTriggerClasses(hasError, variant),
-              "box-border flex w-full",
-              isDisabled && "cursor-not-allowed opacity-50",
-              !isDisabled && "cursor-pointer",
-              className
-            )}
-            onClick={() => !isDisabled && setIsOpen(!isOpen)}
-            onKeyDown={handleKeyDown}
-            tabIndex={isDisabled ? -1 : 0}
-            role="combobox"
-            aria-expanded={isOpen}
-            aria-haspopup="listbox"
-            aria-labelledby={label}
+            ref={selectRef}
+            className="relative w-full"
+            style={{ zIndex: isOpen ? 9999 : "auto" }}
           >
-            {searchable && isOpen ? (
-              <div className="flex min-w-0 flex-1 items-center gap-12">
-                <SearchIcon className="text-grey-600 h-16 w-16 flex-shrink-0" />
-                <input
-                  ref={searchInputRef}
-                  type="text"
-                  placeholder={searchPlaceholder}
-                  value={searchTerm}
-                  onChange={handleSearchChange}
-                  onKeyDown={handleSearchKeyDown}
-                  className="placeholder:text-grey-600 min-w-0 flex-1 border-none bg-transparent text-base font-medium outline-none"
-                  onClick={(e) => e.stopPropagation()}
-                />
-              </div>
-            ) : (
-              <div className="flex min-w-0 flex-1 items-center gap-12">
-                {selectedOption?.photoUrl && (
-                  <img
-                    src={selectedOption.photoUrl}
-                    alt={selectedOption.label}
-                    className="h-24 w-24 flex-shrink-0 rounded-full object-cover"
-                  />
-                )}
-                <span
-                  className={cn(
-                    "min-w-0 flex-1 truncate text-base font-medium",
-                    !selectedOption && "text-grey-600"
-                  )}
-                >
-                  {displayValue}
-                </span>
-              </div>
-            )}
-            <ChevronIcon
-              direction="down"
-              className={cn(
-                "text-grey-600 ml-8 h-16 w-16 flex-shrink-0 transition-transform duration-200",
-                isOpen && "rotate-180"
-              )}
-            />
-          </div>
-
-          {isOpen && dropdownStyle && (
             <div
-              className="border-grey-400 rounded-8 shadow-secondary z-[9999] max-h-240 overflow-auto border bg-white"
-              style={dropdownStyle}
+              ref={selectButtonRef}
+              className={cn(
+                getSelectTriggerClasses(hasError, isDisabled, size, isOpen),
+                !isDisabled && "cursor-pointer",
+                className
+              )}
+              onClick={() => !isDisabled && setIsOpen(!isOpen)}
+              onKeyDown={handleKeyDown}
+              tabIndex={isDisabled ? -1 : 0}
+              role="combobox"
+              aria-expanded={isOpen}
+              aria-haspopup="listbox"
+              aria-invalid={hasError || undefined}
+              aria-required={required || undefined}
             >
-              {filteredOptions.length > 0 ? (
-                filteredOptions.map((option) => (
-                  <div
-                    key={option.value}
-                    className={cn(
-                      "flex min-w-0 cursor-pointer items-center justify-between px-12 py-8",
-                      option.value === value &&
-                        "bg-primary-200 text-primary-600",
-                      option.disabled && "cursor-not-allowed opacity-50",
-                      !option.disabled && "hover:bg-grey-200"
-                    )}
-                    onClick={() => handleSelect(option)}
-                  >
-                    <div className="flex min-w-0 flex-1 items-center gap-12">
-                      {option.photoUrl && (
-                        <img
-                          src={option.photoUrl}
-                          alt={option.label}
-                          className="h-32 w-32 flex-shrink-0 rounded-full object-cover"
-                          onError={(e) => {
-                            e.currentTarget.style.display = "none";
-                          }}
-                        />
+              {searchable && isOpen ? (
+                <div className="flex min-w-0 flex-1 items-center gap-8">
+                  <SearchIcon
+                    className={cn("text-grey-500 shrink-0", iconSizeClass)}
+                  />
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    placeholder={searchPlaceholder}
+                    value={searchTerm}
+                    onChange={handleSearchChange}
+                    onKeyDown={handleSearchKeyDown}
+                    className="placeholder:text-grey-500 min-w-0 flex-1 border-none bg-transparent text-inherit outline-none"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+              ) : (
+                <div className="flex min-w-0 flex-1 items-center gap-8">
+                  {selectedOption?.photoUrl && (
+                    <img
+                      src={selectedOption.photoUrl}
+                      alt={selectedOption.label}
+                      className={cn(
+                        "shrink-0 rounded-full object-cover",
+                        SELECT_TRIGGER_PHOTO_SIZE_CLASSES[size]
                       )}
-                      <span className="w-fit min-w-0 flex-1 truncate text-base font-medium">
-                        {option.label}
-                      </span>
-                      {option.chip && (
-                        <LabelChip
-                          text={option.chip}
-                          size="s"
-                          color={getChipColor(option.chip)}
+                    />
+                  )}
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate",
+                      !selectedOption && "text-grey-500"
+                    )}
+                  >
+                    {displayValue}
+                  </span>
+                </div>
+              )}
+              <ChevronIcon
+                direction="down"
+                className={cn(
+                  "text-grey-500 ml-8 shrink-0 transition-transform duration-200",
+                  iconSizeClass,
+                  isOpen && "rotate-180"
+                )}
+              />
+            </div>
+
+            {isOpen && dropdownStyle && (
+              <div
+                className="border-grey-400 rounded-8 shadow-secondary z-[9999] max-h-240 overflow-auto border bg-white"
+                style={dropdownStyle}
+                role="listbox"
+              >
+                {filteredOptions.length > 0 ? (
+                  filteredOptions.map((option) => (
+                    <div
+                      key={option.value}
+                      className={cn(
+                        "flex min-w-0 cursor-pointer items-center justify-between",
+                        SELECT_OPTION_SIZE_CLASSES[size],
+                        option.value === value &&
+                          "bg-primary-200 text-primary-600",
+                        option.disabled && "cursor-not-allowed opacity-50",
+                        !option.disabled && "hover:bg-grey-200"
+                      )}
+                      onClick={() => handleSelect(option)}
+                      role="option"
+                      aria-selected={option.value === value}
+                    >
+                      <div className="flex min-w-0 items-center gap-8">
+                        {option.photoUrl && (
+                          <img
+                            src={option.photoUrl}
+                            alt={option.label}
+                            className={cn(
+                              "shrink-0 rounded-full object-cover",
+                              SELECT_OPTION_PHOTO_SIZE_CLASSES[size]
+                            )}
+                            onError={(e) => {
+                              e.currentTarget.style.display = "none";
+                            }}
+                          />
+                        )}
+                        <span className="shrink-0">{option.label}</span>
+                        {option.chip && (
+                          <LabelChip
+                            text={option.chip}
+                            size="s"
+                            color={getChipColor(option.chip)}
+                          />
+                        )}
+                      </div>
+                      {option.value === value && (
+                        <CheckCircle
+                          className={cn(
+                            "text-primary-600 ml-8 shrink-0",
+                            SELECT_CHECK_ICON_SIZE_CLASSES[size]
+                          )}
                         />
                       )}
                     </div>
-                    {option.value === value && (
-                      <CheckCircle className="text-primary-600 ml-8 h-16 w-16 flex-shrink-0" />
+                  ))
+                ) : (
+                  <div
+                    className={cn(
+                      "text-grey-500",
+                      SELECT_OPTION_SIZE_CLASSES[size]
                     )}
+                  >
+                    {searchTerm ? "No matching options found" : emptyLabel}
                   </div>
-                ))
-              ) : (
-                <div className="text-grey-600 px-12 py-8">
-                  {searchTerm ? "No matching options found" : emptyLabel}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {errorMessage && (
-          <p className="text-danger-main mt-4 text-xs">{errorMessage}</p>
-        )}
+                )}
+              </div>
+            )}
+          </div>
+        </FieldShell>
       </div>
     );
   }

--- a/src/components/molecules/select/sizes.ts
+++ b/src/components/molecules/select/sizes.ts
@@ -1,0 +1,34 @@
+import type { FieldSize } from "../input-text/types";
+
+export {
+  ADORNMENT_ICON_SIZE_CLASSES as SELECT_ICON_SIZE_CLASSES,
+  INPUT_FIELD_SIZE_CLASSES as SELECT_TRIGGER_SIZE_CLASSES,
+} from "../input-text/sizes";
+
+export const SELECT_OPTION_SIZE_CLASSES: Record<FieldSize, string> = {
+  s: "px-8 py-6 text-caption-1",
+  m: "px-10 py-8 text-body-3",
+  l: "px-12 py-8 text-body-2",
+  xl: "px-14 py-10 text-body-1",
+};
+
+export const SELECT_TRIGGER_PHOTO_SIZE_CLASSES: Record<FieldSize, string> = {
+  s: "size-20",
+  m: "size-24",
+  l: "size-24",
+  xl: "size-28",
+};
+
+export const SELECT_OPTION_PHOTO_SIZE_CLASSES: Record<FieldSize, string> = {
+  s: "size-20",
+  m: "size-24",
+  l: "size-32",
+  xl: "size-36",
+};
+
+export const SELECT_CHECK_ICON_SIZE_CLASSES: Record<FieldSize, string> = {
+  s: "size-12",
+  m: "size-16",
+  l: "size-16",
+  xl: "size-20",
+};

--- a/src/components/molecules/select/types.ts
+++ b/src/components/molecules/select/types.ts
@@ -1,4 +1,4 @@
-export type SelectVariant = "default" | "error";
+import type { FieldSize } from "../input-text/types";
 
 export interface SelectOption {
   label: string;
@@ -16,8 +16,10 @@ export interface SelectProps {
   placeholder?: string;
   required?: boolean;
   errorMessage?: string;
+  helperText?: string;
   disabled?: boolean;
-  variant?: SelectVariant;
+  size?: FieldSize;
+  fullWidth?: boolean;
   className?: string;
   emptyLabel?: string;
   searchable?: boolean;

--- a/src/components/molecules/select/variants.ts
+++ b/src/components/molecules/select/variants.ts
@@ -1,21 +1,20 @@
 import { cn } from "@/lib/utils";
-import type { SelectVariant } from "./types";
-
-const SELECT_BASE_CLASSES =
-  "min-w-0 inline-flex items-center justify-between rounded-8 border bg-white px-12 py-8 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500";
-
-const SELECT_VARIANT_CLASSES: Record<SelectVariant, string> = {
-  default: "border-grey-400 hover:border-grey-6000",
-  error:
-    "border-danger-main focus:ring-danger-main focus:border-danger-main",
-};
+import { getFieldControlClasses } from "../input-text/field-styles";
+import type { FieldSize } from "../input-text/types";
+import { SELECT_TRIGGER_SIZE_CLASSES } from "./sizes";
 
 export function getSelectTriggerClasses(
   hasError: boolean,
-  variant: SelectVariant = "default"
+  disabled: boolean,
+  size: FieldSize,
+  isOpen: boolean
 ): string {
   return cn(
-    SELECT_BASE_CLASSES,
-    SELECT_VARIANT_CLASSES[hasError ? "error" : variant]
+    "box-border flex w-full min-w-0 items-center justify-between",
+    getFieldControlClasses(hasError, disabled, false),
+    SELECT_TRIGGER_SIZE_CLASSES[size],
+    isOpen &&
+      !disabled &&
+      "border-primary-600 shadow-[0_0_0_2px_rgba(0,100,147,0.2)]"
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -396,6 +396,30 @@ const Page = () => {
         </Section>
 
         <Section id="radio" title="RadioButton & RadioGroup">
+          <Sub title="Sizes">
+            <div className="grid gap-24 md:grid-cols-2">
+              {FIELD_SIZES.map((size) => (
+                <RadioGroup
+                  key={size}
+                  label={`Size ${size.toUpperCase()}`}
+                  size={size}
+                  value="a"
+                  options={[
+                    {
+                      label: "Option A",
+                      value: "a",
+                      helperText: "First choice",
+                    },
+                    {
+                      label: "Option B",
+                      value: "b",
+                      helperText: "Second choice",
+                    },
+                  ]}
+                />
+              ))}
+            </div>
+          </Sub>
           <Sub title="RadioButton states">
             <div className="flex flex-col gap-12">
               <RadioButton
@@ -568,6 +592,19 @@ const Page = () => {
         </Section>
 
         <Section id="select" title="Select">
+          <Sub title="Sizes">
+            <div className="grid gap-16 md:grid-cols-2">
+              {FIELD_SIZES.map((size) => (
+                <Select
+                  key={size}
+                  label={`Size ${size.toUpperCase()}`}
+                  options={sampleOptions}
+                  placeholder={`Size ${size}`}
+                  size={size}
+                />
+              ))}
+            </div>
+          </Sub>
           <Sub title="Basic states">
             <div className="grid gap-16 md:grid-cols-2">
               <Select
@@ -657,6 +694,17 @@ const Page = () => {
                 </div>
               ))}
             </div>
+          </Sub>
+          <Sub title="With label">
+            <ScoreIncreaseDecrease
+              label="Set score"
+              helperText="Use +/− to adjust"
+              size="m"
+              score={score}
+              onIncrease={() => setScore((s) => s + 1)}
+              onDecrease={() => setScore((s) => Math.max(0, s - 1))}
+              className="w-[50%]"
+            />
           </Sub>
           <Sub title="States">
             <div className="grid gap-24 md:grid-cols-2">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -185,7 +185,7 @@ const Page = () => {
   const { toast, showToast, hideToast } = useToast();
 
   return (
-    <div className="bg-grey-100 md:bg-warning-200 min-h-screen border p-16 md:p-24">
+    <div className="border-grey-100 md:border-warning-200 m-16 min-h-screen border-8 p-16 md:m-24">
       <div className="mx-auto max-w-5xl space-y-32">
         <header className="space-y-12 text-center">
           <Text variant="h1" color="primary">
@@ -544,8 +544,8 @@ const Page = () => {
                 label="With adornments"
                 type="email"
                 placeholder="Email"
-                startAdornment={<Letter className="size-16" />}
-                endAdornment={<QuestionCircle className="size-16" />}
+                iconLeft={<Letter className="text-primary-950 size-16" />}
+                iconRight={<QuestionCircle className="size-16" />}
               />
             </div>
           </Sub>


### PR DESCRIPTION
## Align form fields with InputText / Figma field styling

### Summary

- Updates **InputText** and **FieldShell** to match Figma (helper icons, adornment prop names).
- Aligns **Select**, **RadioButton**, **RadioGroup**, and **ScoreIncreaseDecrease** with the shared field pattern: `FieldShell`, `field-styles`, `s`/`m`/`l`/`xl` sizes, focus ring/shadow, and consistent error/disabled states.
- Documents Solar **Bold** as an available peer subpath alongside Linear.

---

### InputText & FieldShell

- **FieldShell**
  - Error icon: `DangerCircle` (Linear) → `DangerTriangle` (Bold)
  - Helper icon: `InfoCircle` tinted `text-primary-600`
- **InputText**
  - `startAdornment` / `endAdornment` → **`iconLeft`** / **`iconRight`**
- Docs: README, contributing, agent rules — clarify `@solar-icons/react-perf` covers **Linear** and **Bold** from one peer install

---

### Form field alignment

Shared pattern across Select, Radio, and Score stepper:

- `FieldShell` for label / required / helper / error
- `getFieldControlClasses()` for border, disabled, focus ring
- `size` prop: `s` | `m` | `l` | `xl` (via shared `FieldSize`)
- New `sizes.ts` / `variants.ts` per component

#### Select

- Uses `FieldShell` + shared trigger styles
- Added: `size`, `helperText`, shell className props
- Removed: `variant` (error driven by `errorMessage`)
- Open trigger gets same focus treatment as inputs
- Option rows, icons, and photos scale with `size`

#### RadioButton

- Custom radio control (replaces native `accent-*`) with focus ring
- Added: `size`, `name`, `className`
- Removed: `labelClassName`, `helperTextClassName`
- Typography reuses input-text label/helper size tokens

#### RadioGroup

- Uses `FieldShell`; passes `size` to options
- Block variant uses `getFieldControlClasses()`; selected option gets primary border + focus shadow
- Added: `helperText`, `size`; shared `name` via `useId()`

#### ScoreIncreaseDecrease

- Score box reuses `INPUT_FIELD_SIZE_CLASSES` (same height as InputText) + fixed widths per size
- ± buttons via `IconButton`; `s` matches field height, `m`/`l`/`xl` one step smaller
- Uses `FieldShell` for optional label/helper/error
- Added: `xl` size, optional `label` / `helperText` / `errorMessage`
- `inFocus` kept (used in match UI) but styled as input focus ring instead of tinted background
- Content-width layout (`fullWidth={false}`)

---

### Breaking changes

| Component | Before | After |
|-----------|--------|-------|
| **InputText** | `startAdornment` / `endAdornment` | **`iconLeft`** / **`iconRight`** |
| **Select** | `variant="default" \| "error"` | Removed — use **`errorMessage`** |
| **RadioButton** | `labelClassName`, `helperTextClassName` | Removed — use **`className`** |
| **ScoreIncreaseDecrease** | sizes `s`/`m`/`l` only | Also supports **`xl`** |


---

### Test plan

- [ ] Storybook: **InputText** — icons left/right, helper/error states, all sizes
- [ ] Storybook: **Select** — sizes, searchable, helper/error, open focus ring
- [ ] Storybook: **RadioButton** / **RadioGroup** — sizes, block variant, required/error
- [ ] Storybook: **ScoreIncreaseDecrease** — all sizes, destructive, `inFocus`, editable input, min/max
- [ ] Dev showcase (`pnpm dev`) — field sections render correctly
- [ ] `pnpm build` passes
- [ ] Consumer apps: grep for `startAdornment`, `endAdornment`, Select `variant`, RadioButton `labelClassName`
